### PR TITLE
move logs to appdata folder

### DIFF
--- a/roninsdk/core/logdef.cpp
+++ b/roninsdk/core/logdef.cpp
@@ -18,7 +18,9 @@ void SpdLog_Init(void)
 	}
 
 #ifndef NETCONSOLE
-	g_LogSessionDirectory = fmt::format("ronin\\logs\\{:s}", g_ProcessTimestamp);
+	char appdata[MAX_PATH];
+	GetEnvironmentVariableA("APPDATA", appdata, MAX_PATH);
+	g_LogSessionDirectory = fmt::format("{:s}\\ronin\\logs\\{:s}", appdata, g_ProcessTimestamp);
 	/************************
 	 * GAME CONSOLE LOGGER SETUP   *
 	 ************************/


### PR DESCRIPTION
Myself and I believe one other person have had issues with a mysterious "failed to load RoninSDK.dll" which I have found to be a result of the logs trying to be created in the Titanfall2 folder, which is owned by admin so regular users can't write to it. This PR moves the logs to the %APPDATA% folder, which doesn't require admin perms to write to.