### PR TITLE
move saves to APPDATA

### DIFF
--- a/roninsdk/core/logdef.cpp
+++ b/roninsdk/core/logdef.cpp
@@ -18,7 +18,9 @@ void SpdLog_Init(void)
 	}
 
 #ifndef NETCONSOLE
-	g_LogSessionDirectory = fmt::format("ronin\\logs\\{:s}", g_ProcessTimestamp);
+	char appdata[MAX_PATH];
+	GetEnvironmentVariableA("APPDATA", appdata, MAX_PATH);
+	g_LogSessionDirectory = fmt::format("{:s}\\ronin\\logs\\{:s}", appdata, g_ProcessTimestamp);
 	/************************
 	 * GAME CONSOLE LOGGER SETUP   *
 	 ************************/

--- a/roninsdk/speedrunning/crouchkickfix.h
+++ b/roninsdk/speedrunning/crouchkickfix.h
@@ -158,7 +158,7 @@ inline SQRESULT Script_Ronin_AppendWallrun(HSquirrelVM* sqvm)
 
 	std::string data = sstream.str();
 
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append("ckdata.csv");
 
 	auto mutex = std::ref(g_pSaveFileManager->mutexMap[path]);

--- a/roninsdk/squirrel/sqfiles.cpp
+++ b/roninsdk/squirrel/sqfiles.cpp
@@ -4,11 +4,11 @@
 SaveFileManager::SaveFileManager() {
 	char appdata[MAX_PATH];
 	GetEnvironmentVariableA("APPDATA", appdata, MAX_PATH);
-	SAVE_FILE_DIR = fmt::format("{:s}/ronin", appdata);
+	g_saveFileDir = fmt::format("{:s}/ronin", appdata);
 
 	// old save data location, move everything!!!
 	if(fs::exists("./ronin/data")) {
-		fs::copy("./ronin/data", SAVE_FILE_DIR, std::filesystem::copy_options::recursive);
+		fs::copy("./ronin/data", g_saveFileDir, std::filesystem::copy_options::recursive);
 		fs::remove_all("./ronin/data");
 	}
 }
@@ -127,7 +127,7 @@ void SaveFileManager::DeleteFileAsync(fs::path file)
 
 SQRESULT Script_SaveFile(HSquirrelVM* sqvm)
 {
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	std::string contents = g_pSQManager<ScriptContext::UI>->GetString(sqvm, 2);
@@ -140,7 +140,7 @@ SQRESULT Script_SaveFile(HSquirrelVM* sqvm)
 // loads a file asynchronously
 SQRESULT Script_LoadFile(HSquirrelVM* sqvm)
 {
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	g_pSaveFileManager->LoadFileAsync(path);
@@ -151,7 +151,7 @@ SQRESULT Script_LoadFile(HSquirrelVM* sqvm)
 // returns all files in a directory
 SQRESULT Script_GetFilesInDir(HSquirrelVM* sqvm)
 {
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	g_pSQManager<ScriptContext::UI>->NewArray(sqvm, 0);
@@ -167,7 +167,7 @@ SQRESULT Script_GetFilesInDir(HSquirrelVM* sqvm)
 
 SQRESULT Script_FileExists(HSquirrelVM* sqvm)
 {
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	g_pSQManager<ScriptContext::UI>->PushBool(sqvm, fs::exists(path));
@@ -176,7 +176,7 @@ SQRESULT Script_FileExists(HSquirrelVM* sqvm)
 
 SQRESULT Script_DeleteFile(HSquirrelVM* sqvm)
 {
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 	
 	g_pSaveFileManager->DeleteFileAsync(path);
@@ -187,7 +187,7 @@ SQRESULT Script_DeleteFile(HSquirrelVM* sqvm)
 // returns if we have finished reading a file's contents
 SQRESULT Script_IsFileReady(HSquirrelVM* sqvm)
 {
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	if (g_pSaveFileManager->resultsMap.find(path) == g_pSaveFileManager->resultsMap.end())
@@ -206,7 +206,7 @@ SQRESULT Script_IsFileReady(HSquirrelVM* sqvm)
 // to be read!
 SQRESULT Script_GetFileResults(HSquirrelVM* sqvm)
 {
-	fs::path path = SAVE_FILE_DIR;
+	fs::path path = g_saveFileDir;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	if (g_pSaveFileManager->resultsMap.find(path) == g_pSaveFileManager->resultsMap.end())

--- a/roninsdk/squirrel/sqfiles.cpp
+++ b/roninsdk/squirrel/sqfiles.cpp
@@ -1,6 +1,18 @@
 #include "sqfiles.h"
 #include "squirrelmanager.h"
 
+SaveFileManager::SaveFileManager() {
+	char appdata[MAX_PATH];
+	GetEnvironmentVariableA("APPDATA", appdata, MAX_PATH);
+	SAVE_FILE_DIR = fmt::format("{:s}/ronin", appdata);
+
+	// old save data location, move everything!!!
+	if(fs::exists("./ronin/data")) {
+		fs::copy("./ronin/data", SAVE_FILE_DIR, std::filesystem::copy_options::recursive);
+		fs::remove_all("./ronin/data");
+	}
+}
+
 // Saves a file asynchronously.
 void SaveFileManager::SaveFileAsync(fs::path file, std::string contents)
 {
@@ -164,7 +176,7 @@ SQRESULT Script_FileExists(HSquirrelVM* sqvm)
 
 SQRESULT Script_DeleteFile(HSquirrelVM* sqvm)
 {
-	fs::path path = "./ronin/data";
+	fs::path path = SAVE_FILE_DIR;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 	
 	g_pSaveFileManager->DeleteFileAsync(path);
@@ -175,7 +187,7 @@ SQRESULT Script_DeleteFile(HSquirrelVM* sqvm)
 // returns if we have finished reading a file's contents
 SQRESULT Script_IsFileReady(HSquirrelVM* sqvm)
 {
-	fs::path path = "./ronin/data";
+	fs::path path = SAVE_FILE_DIR;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	if (g_pSaveFileManager->resultsMap.find(path) == g_pSaveFileManager->resultsMap.end())
@@ -194,7 +206,7 @@ SQRESULT Script_IsFileReady(HSquirrelVM* sqvm)
 // to be read!
 SQRESULT Script_GetFileResults(HSquirrelVM* sqvm)
 {
-	fs::path path = "./ronin/data";
+	fs::path path = SAVE_FILE_DIR;
 	path.append(g_pSQManager<ScriptContext::UI>->GetString(sqvm, 1));
 
 	if (g_pSaveFileManager->resultsMap.find(path) == g_pSaveFileManager->resultsMap.end())

--- a/roninsdk/squirrel/sqfiles.h
+++ b/roninsdk/squirrel/sqfiles.h
@@ -2,7 +2,7 @@
 #include "squirrel/sqclasstypes.h"
 #include "core/stdafx.h"
 
-inline string SAVE_FILE_DIR;
+inline string g_saveFileDir;
 
 struct FileResults
 {

--- a/roninsdk/squirrel/sqfiles.h
+++ b/roninsdk/squirrel/sqfiles.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "squirrel/sqclasstypes.h"
+#include "core/stdafx.h"
 
-inline const char* SAVE_FILE_DIR = "./ronin/data";
+inline string SAVE_FILE_DIR;
 
 struct FileResults
 {
@@ -12,6 +13,7 @@ struct FileResults
 class SaveFileManager
 {
 public:
+	SaveFileManager();
 	void SaveFileAsync(fs::path file, std::string content);
 	void LoadFileAsync(fs::path file);
 	void DeleteFileAsync(fs::path file);


### PR DESCRIPTION
makes squirrel scripts write to appdata (along with logs) to stop the administrator launch requirement if titanfall 2 is in program files